### PR TITLE
Extract card component, fix too wide style

### DIFF
--- a/app/models/Cards.scala
+++ b/app/models/Cards.scala
@@ -33,7 +33,7 @@ case class CardValue(id: String, position: Int, endValue: Int)
 
 trait Card {
   val id: String
-  val gameString: String
+  val gameRepresentation: Seq[String]
   val endValue: Int
 }
 
@@ -50,13 +50,13 @@ object Card {
 
 case class RegularCard(suit: Suit, value: CardValue) extends Card {
   val id         = suit.id + value.id
-  val gameString = suit.icon + value.id
+  val gameRepresentation = Seq(suit.icon, value.id)
   val endValue   = value.endValue
 }
 
 case class Joker(number: Int) extends Card {
   val id         = s"J$number"
-  val gameString = "☆J"
+  val gameRepresentation = Seq("☆", "J")
   val endValue   = 0
 
 }

--- a/app/models/Cards.scala
+++ b/app/models/Cards.scala
@@ -49,15 +49,15 @@ object Card {
 }
 
 case class RegularCard(suit: Suit, value: CardValue) extends Card {
-  val id         = suit.id + value.id
+  val id                 = suit.id + value.id
   val gameRepresentation = Seq(suit.icon, value.id)
-  val endValue   = value.endValue
+  val endValue           = value.endValue
 }
 
 case class Joker(number: Int) extends Card {
-  val id         = s"J$number"
+  val id                 = s"J$number"
   val gameRepresentation = Seq("☆", "J")
-  val endValue   = 0
+  val endValue           = 0
 
 }
 

--- a/app/models/DummyGame.scala
+++ b/app/models/DummyGame.scala
@@ -1,5 +1,6 @@
 package models
 
+import models.Shuffle.ShuffleResult
 import models.series.{GameIsRunning, GameSeriesConfig, GameSeriesLogic, GameSeriesState, PlayerInfo, WaitingForNextGame}
 
 import scala.collection.mutable
@@ -82,6 +83,46 @@ object DummyGame {
         lastWinner = None,
         scores = Map("p1"     -> 25, "p2"          -> 15),
         scoresDiff = Map("p1" -> Seq(2, -25), "p2" -> Seq(4))
+      )
+    )
+  }
+
+  val fiveCardsOnPile = "g4" -> {
+    val config = GameSeriesConfig.Default
+    val shuffled = ShuffleResult(Seq(Seq(
+      Card.fromString("H7").get,
+      Card.fromString("H8").get,
+      Card.fromString("H9").get,
+      Card.fromString("H10").get,
+      Card.fromString("HJ").get
+    )), deck = Cards.Deck,
+      pile = Pile(Seq(Card.fromString("H2").get,
+        Card.fromString("H3").get,
+        Card.fromString("H4").get,
+        Card.fromString("H5").get,
+        Card.fromString("H6").get), Seq.empty, Seq.empty))
+
+    mutable.Buffer(
+      GameSeriesState(
+        config,
+        id = "g4",
+        version = 1,
+        players = Seq(PlayerInfo("p1", "Max")),
+        state = GameIsRunning,
+        currentGame = Some(
+          GameState(
+            config = config.gameConfig,
+            players = Seq(PlayerCards("p1", shuffled.playerCards.head, None)),
+            currentPlayer = "p1",
+            nextAction = Throw,
+            pile = shuffled.pile,
+            deck = shuffled.deck,
+            ending = None
+          )
+        ),
+        lastWinner = None,
+        scores = Map("p1" -> 0),
+        scoresDiff = Map("p1" -> Seq(0))
       )
     )
   }

--- a/app/models/DummyGame.scala
+++ b/app/models/DummyGame.scala
@@ -89,18 +89,29 @@ object DummyGame {
 
   val fiveCardsOnPile = "g4" -> {
     val config = GameSeriesConfig.Default
-    val shuffled = ShuffleResult(Seq(Seq(
-      Card.fromString("H7").get,
-      Card.fromString("H8").get,
-      Card.fromString("H9").get,
-      Card.fromString("H10").get,
-      Card.fromString("HJ").get
-    )), deck = Cards.Deck,
-      pile = Pile(Seq(Card.fromString("H2").get,
-        Card.fromString("H3").get,
-        Card.fromString("H4").get,
-        Card.fromString("H5").get,
-        Card.fromString("H6").get), Seq.empty, Seq.empty))
+    val shuffled = ShuffleResult(
+      Seq(
+        Seq(
+          Card.fromString("H7").get,
+          Card.fromString("H8").get,
+          Card.fromString("H9").get,
+          Card.fromString("H10").get,
+          Card.fromString("HJ").get
+        )
+      ),
+      deck = Cards.Deck,
+      pile = Pile(
+        Seq(
+          Card.fromString("H2").get,
+          Card.fromString("H3").get,
+          Card.fromString("H4").get,
+          Card.fromString("H5").get,
+          Card.fromString("H6").get
+        ),
+        Seq.empty,
+        Seq.empty
+      )
+    )
 
     mutable.Buffer(
       GameSeriesState(
@@ -121,7 +132,7 @@ object DummyGame {
           )
         ),
         lastWinner = None,
-        scores = Map("p1" -> 0),
+        scores = Map("p1"     -> 0),
         scoresDiff = Map("p1" -> Seq(0))
       )
     )

--- a/app/models/JsonImplicits.scala
+++ b/app/models/JsonImplicits.scala
@@ -23,10 +23,10 @@ object JsonImplicits {
     case e => JsError(s"Not a valid card id: $e")
   }
 
-  case class JsonCard(id: String, gameString: String, endValue: Int) extends Card
+  case class JsonCard(id: String, gameRepresentation: Seq[String], endValue: Int) extends Card
 
   implicit val cardWrites: Writes[Card] = Writes { card =>
-    Json.writes[JsonCard].writes(JsonCard(card.id, card.gameString, card.endValue))
+    Json.writes[JsonCard].writes(JsonCard(card.id, card.gameRepresentation, card.endValue))
   }
   implicit val drawableCardReads: Reads[DrawableCard]   = Json.reads[DrawableCard]
   implicit val drawableCardWrites: Writes[DrawableCard] = Json.writes[DrawableCard]

--- a/app/service/GamesService.scala
+++ b/app/service/GamesService.scala
@@ -19,6 +19,7 @@ class GamesService(implicit as: ActorSystem, mat: Materializer) {
   gameSeriesStates += DummyGame.dummyGame
   gameSeriesStates += DummyGame.drawThrowTest
   gameSeriesStates += DummyGame.betweenGames
+  gameSeriesStates += DummyGame.fiveCardsOnPile
 
   val preGameConnectionManager: ActorRef = as.actorOf(ConnectionManager.props[GameSeriesId, GameSeriesPreStartInfo])
   val inGameConnectionManager: ActorRef =

--- a/frontend/src/card.js
+++ b/frontend/src/card.js
@@ -1,0 +1,22 @@
+const color = (card) => {
+	if (card.id[0] === 'H' || card.id[0] === 'D') return 'red';
+	if (card.id[0] === 'C' || card.id[0] === 'S') return '';
+	return 'green';
+};
+
+const renderString = (card) => <span>{card.gameRepresentation[0]}<wbr />{card.gameRepresentation[1]}</span>;
+
+const wrappedAction = (playable, action) => playable ? action : null;
+
+export const Card = ({ card, classes, playable, backside, action }) => {
+	const playableClass = playable ? 'playable': 'inactive';
+	const backsideClass = backside ? 'backside' : '';
+	return (
+		<div className={`game-card ${playableClass} ${backsideClass} ${card ? color(card) : ''} ${classes}`}
+			disabled={!playable}
+			onClick={wrappedAction(playable, action)}
+		>
+			{card ? renderString(card) : ''}
+		</div>
+	);
+};

--- a/frontend/src/join.js
+++ b/frontend/src/join.js
@@ -200,7 +200,7 @@ export class Join extends Component {
 						</div>
 					</div>
 				)}
-				{debug ? (<pre>{JSON.stringify(this.state)} {JSON.stringify(this.props)}</pre>) : <div/>}
+				{debug ? (<pre>{JSON.stringify(this.state)} {JSON.stringify(this.props)}</pre>) : <div />}
 			</div>
 		);
 	}

--- a/frontend/src/scores.js
+++ b/frontend/src/scores.js
@@ -5,19 +5,20 @@ const cardsStrings = (cards) => {
 	if (typeof cards === 'number') {
 		return [cards];
 	}
-	return cards.map(c => c.gameString);
+	return cards.map(c => c.gameRepresentation.join('')); // TODO this is never shown
 };
 
 const renderScoreDiff = (scores) => {
-	const rendered = []
+	const rendered = [];
 	scores.map(score => {
 		if (score > 0) {
 			rendered.push(`+${score}`);
-		} else if (score < 0) {
+		}
+		else if (score < 0) {
 			rendered.push(`–${-score}`);
 		}
 	});
-	return (rendered.length > 0) ? `(${rendered.join(" ")})` : ''
+	return (rendered.length > 0) ? `(${rendered.join(' ')})` : '';
 };
 
 

--- a/frontend/src/style.scss
+++ b/frontend/src/style.scss
@@ -19,14 +19,15 @@
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	font-size: 2.5vh;
-	/* text-align: center; */
+	font-size: 120%;
+	line-height: 120%;
+	text-align: center;
 	background-color: white;
 	height: 10vh;
-	min-width: 60px;
-	width: calc(100% - 1vh);
+	min-width: 4vw;
+	width: calc(100% - 1vw);
 	vertical-align: middle;
-	margin: 0 0.5vh;
+	margin: 0 0.5vw;
 	border: 1px solid #ccc;
 	border-radius: 10px;
 }
@@ -106,7 +107,7 @@
 }
 
 .pile-container {
-	width: 50%;
+	width: 70%;
 }
 
 .top-container {
@@ -130,13 +131,19 @@
 	margin: -7vh auto 0;
 }
 
+// card size = 1/5 * full width - 1vw == 20% - 1vw
+// in 70% wide pile container: 100% * 2/7 - 1vw
+
 .pile-card {
 	position: relative;
-	width: calc(40% - 1vh);
+	max-width: calc(100% * (2/7) - 1vw);
+	overflow: hidden;
 }
 
+// in 30% wide container: 100% * 2/3 - 1vw
+
 .deck-card {
-	width: calc(40% - 1vh);
+	width: calc(100% * (2/3) - 1vw);
 }
 
 .deck {
@@ -144,7 +151,7 @@
 }
 
 .deck-container {
-	width: 50%;
+	width: 30%;
 	display: flex;
 	flex-direction: column;
 	justify-content: center;

--- a/frontend/src/table.js
+++ b/frontend/src/table.js
@@ -1,38 +1,21 @@
+import { Card } from './card';
+
 export const Pile = ({ pile, disabled, drawAction, cardColor }) => (
 	<div class="pile-container">
 		<div class="top-container">
-			{pile.top.map(card =>
-				(<div className={`game-card pile-card inactive ${cardColor(card)}`}>{card.gameString}</div>)
-			)}
+			{pile.top.map(card => <Card card={card} playable={false} classes="pile-card" />)}
 		</div>
 		<div class="drawable-container">
-			{pile.drawable.map(pileCard => {
-				const classes = `game-card pile-card ${(!disabled && pileCard.drawable) ? 'playable' : 'inactive'} ${cardColor(pileCard.card)}`;
-				return (<div className={classes} onClick={e => { if (!disabled && pileCard.drawable) drawAction(pileCard.card); }}>
-					{pileCard.card.gameString}
-				</div>);
-			})}
+			{pile.drawable.map(pileCard =>
+				<Card card={pileCard.card} playable={!disabled && pileCard.drawable} classes="pile-card" action={e => drawAction(pileCard.card)} />)}
 		</div>
-		{pile.bottom > 0 ? <div class="game-card pile-card backside pile-bottom" /> : <div />}
+		{pile.bottom > 0 ? <Card playable={false} backside classes="pile-card pile-bottom" /> : <div />}
 	</div>
 );
 
-export const Backside = ({ disabled, action }) => (
-	<div class={`game-card deck-card deck backside ${(!disabled) ? 'playable' : 'inactive'}`}
-		disabled={disabled}
-		onClick={action}
-	/>
-);
-
-export const CardOnDeck = ({ card, action, cardColor }) => (
-	<div class={`game-card deck-card deck playable ${cardColor(card)}`}
-		onClick={action}
-	>{card.gameString}</div>
-);
-
-
 export const Deck = ({ deck, cardOnDeck, disabled, drawAction, drawThrowAction, cardColor }) => (
 	<div class="deck-container">
-		{cardOnDeck ? <CardOnDeck card={cardOnDeck} action={drawThrowAction} cardColor={cardColor} /> : <Backside disabled={disabled} action={drawAction} />}
+		{cardOnDeck ? <Card classes={'deck-card'} card={cardOnDeck} playable action={drawThrowAction} /> :
+			<Card classes={'deck-card'} backside playable={!disabled} action={drawAction} />}
 	</div>
 );


### PR DESCRIPTION
Fixes #14: pile cards shrink now if there are too many. Added `<wbr>` to the card strings to fit even smaller screens

<img width="526" alt="Screenshot 2020-05-09 at 15 55 16" src="https://user-images.githubusercontent.com/1640908/81475598-99c0c900-920d-11ea-9352-3ac75ddac61d.png">
<img width="270" alt="Screenshot 2020-05-09 at 15 55 09" src="https://user-images.githubusercontent.com/1640908/81475603-9d545000-920d-11ea-82dd-295a8245293d.png">


 